### PR TITLE
Backport to librtaudio 5.0.0 for Debian Buster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ else()
                 imguiplot
                 fftw3
                 m
+                stdc++fs
+                stdc++
                 pthread
                 rtaudio)
 endif()

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The only dependencies of laa should be
  * SDL2, >= 2.0.8
  * fftw3, >= 3.3.8
  * OpenGL libraries 
- * rtaudio, >= 5.1.0
+ * rtaudio, >= 5.0.0
  
 Other versions might work (especially so for sdl2), so rolling release systems (arch, void, ...) should be fine.
  
@@ -40,7 +40,12 @@ Afterwards, it should be the usual cmake workflow
 
     cd /place/where/you/put/laa
     mkdir build && cd build
+
+    # If your librtaudio < 5.1.0:
+    cmake -D CMAKE_CXX_FLAGS=-DRTAUDIO500=1 ..
+    # Else:
     cmake ..
+
     make -j
     sudo make install 
     

--- a/src/audio/audiohandler_ui.cpp
+++ b/src/audio/audiohandler_ui.cpp
@@ -54,6 +54,38 @@ std::string getStr(const StateWindowFilter& filter) noexcept
     return "";
 }
 
+static std::string ApiName(const RtAudio::Api AApi)
+{
+#if defined(RTAUDIO500)
+    switch(AApi) {
+    case RtAudio::UNSPECIFIED: /*!< Search for a working compiled API. */
+        return "Unspecified";
+    case RtAudio::LINUX_ALSA:     /*!< The Advanced Linux Sound Architecture API. */
+        return "ALSA";
+    case RtAudio::LINUX_PULSE:    /*!< The Linux PulseAudio API. */
+        return "Pulse";
+    case RtAudio::LINUX_OSS:      /*!< The Linux Open Sound System API. */
+        return "OSS";
+    case RtAudio::UNIX_JACK:      /*!< The Jack Low-Latency Audio Server API. */
+        return "JACK";
+    case RtAudio::MACOSX_CORE:    /*!< Macintosh OS-X Core Audio API. */
+        return "Core";
+    case RtAudio::WINDOWS_WASAPI: /*!< The Microsoft WASAPI API. */
+        return "WASAPI";
+    case RtAudio::WINDOWS_ASIO:   /*!< The Steinberg Audio Stream I/O API. */
+        return "ASIO";
+    case RtAudio::WINDOWS_DS:     /*!< The Microsoft Direct Sound API. */
+        return "DirectSound";
+    case RtAudio::RTAUDIO_DUMMY:  /*!< A compilable but non-functional API. */
+        return "Dummy";
+    default:
+        return "(INVALID)";
+    }
+#else
+    return RtAudio::getApiDisplayName(AApi);
+#endif
+}
+
 void AudioHandler::update() noexcept
 {
     ImGui::Begin("Audio Settings", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysVerticalScrollbar);
@@ -62,9 +94,9 @@ void AudioHandler::update() noexcept
         ImGui::TextWrapped("Driver");
         std::vector<RtAudio::Api> rtAudioApis;
         RtAudio::getCompiledApi(rtAudioApis);
-        if (ImGui::BeginCombo("##apiSelect", RtAudio::getApiDisplayName(rtAudio->getCurrentApi()).c_str())) {
+        if (ImGui::BeginCombo("##apiSelect", ApiName(rtAudio->getCurrentApi()).c_str())) {
             for (auto& api : rtAudioApis) {
-                if (ImGui::Selectable(RtAudio::getApiDisplayName(api).c_str(), api == rtAudio->getCurrentApi())) {
+                if (ImGui::Selectable(ApiName(api).c_str(), api == rtAudio->getCurrentApi())) {
                     rtAudio = std::make_unique<RtAudio>(api);
                     if (rtAudio == nullptr) {
                         rtAudio = std::make_unique<RtAudio>();


### PR DESCRIPTION
There are probably better ways to deal with the RTAudio version (automatic detection), but this change makes laa compile in the current Stable release of Debian (10.xx, "Buster")